### PR TITLE
Possible fix for discid error/submit URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cdripper"
-version = "2.0.0"
+version = "2.0.1"
 description = "Package for automagically rip and tag CDs when inserted"
 readme = "README.md"
 authors = [

--- a/src/cdripper/ui/dialogs.py
+++ b/src/cdripper/ui/dialogs.py
@@ -516,6 +516,12 @@ class MyTableModel(QtCore.QAbstractTableModel):
             return ""
 
     def columnCount(self, parent=None):
+        if not isinstance(self.data, list):
+            return 0
+
+        if len(self.data) == 0:
+            return 0
+
         return len(self.data[0])
 
     def rowCount(self, parent=None):


### PR DESCRIPTION
Had an edge case where a video disc was recognized as an audio disc, cause musicbrainz to try to grab a submit URL, which cause a break in the code. This version tries to handle this issue by better checking the result of the metadata search.